### PR TITLE
fix: pass timeout to async wait to enable polling fallback for legacy Chroma SDK games

### DIFF
--- a/src/RazerSdkReader/Extensions/EventWaitHandleExtensions.cs
+++ b/src/RazerSdkReader/Extensions/EventWaitHandleExtensions.cs
@@ -5,25 +5,22 @@ namespace RazerSdkReader.Extensions;
 
 internal static class EventWaitHandleExtensions
 {
-    public static ValueTask<bool> WaitOneAsync(this EventWaitHandle handle, int syncTimeoutMs, CancellationToken cancellationToken = default)
+    public static ValueTask<bool> WaitOneAsync(this EventWaitHandle handle, int timeoutMs, CancellationToken cancellationToken = default)
     {
-        // Handle synchronous cases.
-        if (handle.WaitOne(syncTimeoutMs))
+        // Check if already signaled without blocking.
+        if (handle.WaitOne(0))
             return ValueTask.FromResult(true);
 
-        return handle.WaitOneAsync(cancellationToken);
-    }
-
-    //separate async case to avoid closure allocation in the common case
-    private static ValueTask<bool> WaitOneAsync(this EventWaitHandle handle, CancellationToken cancellationToken = default)
-    {
-        // Register all asynchronous cases.
+        // Register async wait with the caller's timeout so the ReadLoop gets a
+        // guaranteed polling fallback even when the event is never signaled (e.g.
+        // legacy Chroma SDK games that write directly to shared memory without
+        // signaling the update event handle).
         var tcs = new TaskCompletionSource<bool>();
         var threadPoolRegistration = ThreadPool.RegisterWaitForSingleObject(
             handle,
             static (state, timedOut) => ((TaskCompletionSource<bool>)state!).TrySetResult(!timedOut),
             tcs,
-            -1,
+            timeoutMs,
             true);
         cancellationToken.Register(() => tcs.TrySetCanceled(), useSynchronizationContext: false);
         tcs.Task.ContinueWith(_ => threadPoolRegistration.Unregister(null), TaskScheduler.Default);


### PR DESCRIPTION
## Problem

The code comment in `SignaledReader.ReadLoop` describes the intended behaviour:

```csharp
// try to wait synchronously for 5 seconds,
// if it times out, then wait asynchronously.
// hopefully this is a good compromise between
// performance and responsiveness.
await _eventWaitHandle!.WaitOneAsync(5000, _cts.Token);
```

The intent is clear: wait up to 5 seconds, then read regardless. For games that signal the event frequently this is a fast-path; for games that never signal it acts as a 5-second poll.

The implementation does not deliver this. After the synchronous wait times out, the call falls through to the private overload which passes `-1` (infinite) to `RegisterWaitForSingleObject`:

```csharp
public static ValueTask<bool> WaitOneAsync(this EventWaitHandle handle, int syncTimeoutMs, ...)
{
    if (handle.WaitOne(syncTimeoutMs))          // waits up to syncTimeoutMs
        return ValueTask.FromResult(true);

    return handle.WaitOneAsync(cancellationToken); // ← infinite wait, never times out
}
```

`SignaledReader.ReadLoop` therefore blocks forever on the second iteration for any game that does not signal the event handle — directly contradicting the comment above it.

**Observed impact:** legacy Chroma SDK games (pre-Synapse 3) write color data directly to the shared memory segments but never signal the associated `EventWaitHandle`. Without the fix, their colors are read exactly once (the initial read before the loop), then never updated again.

## Fix

Implement what the comment already promises: honour the caller's timeout in the async path by passing `timeoutMs` to `RegisterWaitForSingleObject` instead of `-1`.

`RegisterWaitForSingleObject` fires the callback either when the handle is signaled or when `timeoutMs` elapses — the `timedOut` flag distinguishes the two cases. This gives:

- **Modern games (frequent signals):** `WaitOne(0)` fast-path returns immediately; async registration fires on the next signal. No behaviour change.
- **Legacy games (no signals):** callback fires after 5 seconds, data is re-read. Effectively a 5-second poll, exactly as the comment describes.

## Behaviour

| Game type | Before | After |
|---|---|---|
| Modern Chroma SDK (signals event) | Immediate update | Immediate update (unchanged) |
| Legacy Chroma SDK (no event signal) | Read once at startup, then frozen | Polled every 5 seconds |

## Verification

Verified by IL-patching the `RazerSdkReader.dll` bundled with Aurora-RGB/Aurora v383 (changing the `-1` constant to `5000` in the compiled binary) and confirming that 007: First Light (a legacy Chroma SDK game) now updates continuously without any manual intervention. Factorio and Diablo IV (modern SDK games) were unaffected.