### PR TITLE
feat: RestartReaders — re-attach all signaled readers after a Chroma service restart

### DIFF
--- a/src/RazerSdkReader/ChromaReader.cs
+++ b/src/RazerSdkReader/ChromaReader.cs
@@ -143,6 +143,29 @@ public sealed class ChromaReader : IDisposable
         }
     }
 
+    public void RestartReaders()
+    {
+        if (_chromaMutex == null) return;
+
+        Action<object?, RazerSdkReaderException> onReaderException = (sender, e) => Exception?.Invoke(sender, e);
+
+        _appDataReader.Stop();
+        _keyboardReader.Stop();
+        _mouseReader.Stop();
+        _mousepadReader.Stop();
+        _keypadReader.Stop();
+        _headsetReader.Stop();
+        _chromaLinkReader.Stop();
+
+        if (EnableAppData) _appDataReader.Start(ReaderDefinitions.AppData, onReaderException);
+        if (EnableKeyboard) _keyboardReader.Start(ReaderDefinitions.Keyboard, onReaderException);
+        if (EnableMouse) _mouseReader.Start(ReaderDefinitions.Mouse, onReaderException);
+        if (EnableMousepad) _mousepadReader.Start(ReaderDefinitions.Mousepad, onReaderException);
+        if (EnableKeypad) _keypadReader.Start(ReaderDefinitions.Keypad, onReaderException);
+        if (EnableHeadset) _headsetReader.Start(ReaderDefinitions.Headset, onReaderException);
+        if (EnableChromaLink) _chromaLinkReader.Start(ReaderDefinitions.Link, onReaderException);
+    }
+
     private static void Subscribe<T>(bool enable, SignaledReader<T> store, InStructEventHandler<T>? value) where T : unmanaged
     {
         if (!enable) throw new InvalidOperationException($"{typeof(T).Name} is not enabled, this event will never fire.");

--- a/src/RazerSdkReader/SignaledReader.cs
+++ b/src/RazerSdkReader/SignaledReader.cs
@@ -54,7 +54,7 @@ internal sealed class SignaledReader<T> : IDisposable where T : unmanaged
         }
     }
 
-    public void Dispose()
+    internal void Stop()
     {
         _cts?.Cancel();
         _task?.Wait();
@@ -62,6 +62,15 @@ internal sealed class SignaledReader<T> : IDisposable where T : unmanaged
         _task?.Dispose();
         _reader?.Dispose();
         _eventWaitHandle?.Dispose();
+        _cts = null;
+        _task = null;
+        _reader = null;
+        _eventWaitHandle = null;
+    }
+
+    public void Dispose()
+    {
+        Stop();
         Updated = null;
         _exceptionHandler = null;
     }


### PR DESCRIPTION
**This pull request proposes the following changes:**
- `SignaledReader<T>` gains an internal `Stop()` — the teardown half of `Dispose()` (cancel loop, dispose reader/handle, null the fields) without clearing the `Updated` event handlers, so a reader can be re-armed.
- `ChromaReader.RestartReaders()` stops and restarts every enabled reader in place.

**Why:** long-lived consumers (e.g. [Aurora](https://github.com/Aurora-RGB/Aurora)) outlive Razer Chroma service restarts. When `RzSDKService` goes away and comes back, the previously opened memory-mapped files and event wait handles are stale; the only options today are recreating the whole `ChromaReader` (and re-wiring every event subscription) or leaking the old readers. `RestartReaders()` re-attaches in place while keeping all subscriptions intact. Aurora is running this in production (it watches the service process and calls `RestartReaders()` when the service comes back up).

Complements #4 (polling fallback), but independent of it.

**Known issues/To do:**
- none known
