### PR TITLE
fix: reset the ManualReset event after every wake

### DIFF
--- a/src/RazerSdkReader/SignaledReader.cs
+++ b/src/RazerSdkReader/SignaledReader.cs
@@ -40,6 +40,9 @@ internal sealed class SignaledReader<T> : IDisposable where T : unmanaged
                 // hopefully this is a good compromise between
                 // performance and responsiveness.
                 await _eventWaitHandle!.WaitOneAsync(5000, _cts.Token);
+                // The emulator events are ManualReset: reset after every wake, or a writer that
+                // Sets without Resetting leaves the handle signaled and the loop busy-polls.
+                _eventWaitHandle!.Reset();
                 data = _reader!.Read();
                 Updated?.Invoke(this, in data);
             }


### PR DESCRIPTION
**This pull request proposes the following changes:**
- `SignaledReader.ReadLoop` resets the (ManualReset) event handle after every wake.

**Why:** the Chroma emulator event handles are created as `EventResetMode.ManualReset`. A writer that `Set`s without an immediate `Reset` leaves the handle signaled, so `WaitOne` returns instantly on every iteration and the read loop busy-polls at 100% duty. Resetting after each wake makes the loop robust regardless of the writer's pulse discipline. This is the same behaviour as the privately-built copy of this library that Aurora has vendored since 2023 ("manual event reset fix") — with this merged, Aurora can return to the published package.

Complements #4 and #6; independent of both.

**Known issues/To do:**
- none known
